### PR TITLE
accountUrn and userUrn start with urn:account:uuid and urn:user:uuid:

### DIFF
--- a/src/main/java/net/smartcosmos/cluster/userdetails/UserDetailsResource.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/UserDetailsResource.java
@@ -45,8 +45,8 @@ public class UserDetailsResource {
             passwordHash = passwordEncoder.encode(credentials);
         }
 
-        final String accountUrn = "urn:account:53f452c2-5a01-44fd-9956-3ecff7c32b30";
-        final String userUrn = "urn:user:53f452c2-5a01-44fd-9956-3ecff7c32b30";
+        final String accountUrn = "urn:account:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
+        final String userUrn = "urn:user:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
 
         return UserDto.builder().accountUrn(accountUrn).userUrn(userUrn)
                 .username(username).passwordHash(passwordHash)
@@ -69,8 +69,8 @@ public class UserDetailsResource {
 
         log.info("Requested information for details only on username {}", username);
 
-        final String accountUrn = "urn:account:53f452c2-5a01-44fd-9956-3ecff7c32b30";
-        final String userUrn = "urn:user:53f452c2-5a01-44fd-9956-3ecff7c32b30";
+        final String accountUrn = "urn:account:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
+        final String userUrn = "urn:user:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
 
         return UserDto.builder().accountUrn(accountUrn).userUrn(userUrn)
                 .username(username).roles(Arrays.asList("ROLE_USER")).build();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Temporary tenantUrn and userUrn fields now start with urn:*:uuid: to match expectations from UuidUtil.java.
### How is this patch documented?

String constants in code.
### How was this patch tested?

All existing tests still working, and something that was broken in Postman is now healthy again.
#### Depends On

Nothing.
