### PR TITLE
Feature/objects 927

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,15 +13,23 @@ The **User Details Service** is slight modification of the __Directory Service__
 This assumes your relative location is this folder.  The **Auth Server** needs to authenticate against the **User Details Service** with a secure login and password.  This is defined inside your SMART COSMOS Configuration under `smartcosmos.security.resource.userDetails.username` and `smartcosmos.security.resource.userDetails.password`
 
 ----
-curl -X POST http://user:password@localhost:42000/test --data "{}" -H "Content-Type: application/json" | jq
+curl -X POST http://user:password@localhost:42000/authenticate \
+--data '{"details":{"grant_type":"password","scope":"read","username":"test"},"authorities":[],"authenticated":false,"principal":"test","credentials":"password","":"test"}' \
+-H "Content-Type: application/json" | json_pp
 ----
 
-If you changed `user` and `password` to match correctly, you should see something similar to the following:
+If you changed `user` and `password` in the request to match correctly, you should see something similar to the following:
 
 ----
-[
-  "https://authorities.smartcosmos.net/things/read"
-]
+{
+   "authorities" : [
+      "https://authorities.smartcosmos.net/things/read"
+   ],
+   "tenantUrn" : "urn:account:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30",
+   "userUrn" : "urn:user:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30",
+   "username" : "test",
+   "passwordHash" : ""
+}
 ----
 
 This represents the array of *authorities* that the user (in this case with username *test* and empty credentials) has on the cluster.

--- a/README.adoc
+++ b/README.adoc
@@ -20,11 +20,11 @@ If you changed `user` and `password` to match correctly, you should see somethin
 
 ----
 [
-  "ROLE_USER"
+  "https://authorities.smartcosmos.net/things/read"
 ]
 ----
 
-This represents the array of *roles* that the user (in this case with username *test* and empty credentials) has on the cluster.
+This represents the array of *authorities* that the user (in this case with username *test* and empty credentials) has on the cluster.
 
 Not to be confused with the credentials the **Auth Server** used to authenticate against the **User Details Service**.
 

--- a/src/main/java/net/smartcosmos/cluster/userdetails/UserDetailsResource.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/UserDetailsResource.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import lombok.extern.slf4j.Slf4j;
-import net.smartcosmos.cluster.userdetails.domain.UserDto;
 
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ObjectNode;
@@ -12,7 +11,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import net.smartcosmos.cluster.userdetails.domain.UserDto;
 
 @RestController
 @Slf4j
@@ -48,9 +53,9 @@ public class UserDetailsResource {
         final String accountUrn = "urn:account:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
         final String userUrn = "urn:user:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
 
-        return UserDto.builder().accountUrn(accountUrn).userUrn(userUrn)
+        return UserDto.builder().tenantUrn(accountUrn).userUrn(userUrn)
                 .username(username).passwordHash(passwordHash)
-                .roles(Arrays.asList("ROLE_USER")).build();
+                .authorities(Arrays.asList("https://authorities.smartcosmos.net/things/read")).build();
     }
 
     /**
@@ -72,8 +77,8 @@ public class UserDetailsResource {
         final String accountUrn = "urn:account:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
         final String userUrn = "urn:user:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
 
-        return UserDto.builder().accountUrn(accountUrn).userUrn(userUrn)
-                .username(username).roles(Arrays.asList("ROLE_USER")).build();
+        return UserDto.builder().tenantUrn(accountUrn).userUrn(userUrn)
+                .username(username).authorities(Arrays.asList("https://authorities.smartcosmos.net/things/read")).build();
 
     }
 }

--- a/src/main/java/net/smartcosmos/cluster/userdetails/UserDetailsResource.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/UserDetailsResource.java
@@ -2,21 +2,22 @@ package net.smartcosmos.cluster.userdetails;
 
 import java.io.IOException;
 import java.util.Arrays;
+import javax.validation.Valid;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ObjectNode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import net.smartcosmos.cluster.userdetails.domain.AuthenticateRequest;
 import net.smartcosmos.cluster.userdetails.domain.UserDto;
 
 @RestController
@@ -29,20 +30,16 @@ public class UserDetailsResource {
     @Autowired
     ObjectMapper objectMapper;
 
-    @RequestMapping(value = "{username}", method = RequestMethod.POST)
-    public UserDto authenticate(@PathVariable("username") String username,
-            @RequestBody byte[] requestBody)
+    @RequestMapping(value = "authenticate", method = RequestMethod.POST)
+    public UserDto authenticate(@RequestBody @Valid AuthenticateRequest authentication)
                     throws UsernameNotFoundException, IOException {
 
-        final ObjectNode authentication = objectMapper.readValue(requestBody,
-                ObjectNode.class);
-
-        log.info("Requested information on username {} with {}", username,
+        log.info("Requested information on username {} with {}", authentication.getName(),
                 authentication);
 
         String passwordHash = null;
-        if (authentication.has("credentials")) {
-            String credentials = authentication.get("credentials").asText();
+        if (StringUtils.isNotBlank(authentication.getCredentials())) {
+            String credentials = authentication.getCredentials();
             if (!"password".equals(credentials)) {
                 log.error("Password incorrect.");
                 throw new BadCredentialsException("Invalid password");
@@ -54,31 +51,7 @@ public class UserDetailsResource {
         final String userUrn = "urn:user:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
 
         return UserDto.builder().tenantUrn(accountUrn).userUrn(userUrn)
-                .username(username).passwordHash(passwordHash)
+                .username(authentication.getName()).passwordHash(passwordHash)
                 .authorities(Arrays.asList("https://authorities.smartcosmos.net/things/read")).build();
-    }
-
-    /**
-     * The GET method only returns the details on the user, removing the password hash
-     * component. This is not cached in the authorization server, and is merely a fallback
-     * method for the user details service.
-     *
-     * @param username
-     * @return
-     * @throws UsernameNotFoundException
-     * @throws IOException
-     */
-    @RequestMapping(value = "{username}")
-    public UserDto authenticate(@PathVariable("username") String username)
-            throws UsernameNotFoundException, IOException {
-
-        log.info("Requested information for details only on username {}", username);
-
-        final String accountUrn = "urn:account:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
-        final String userUrn = "urn:user:uuid:53f452c2-5a01-44fd-9956-3ecff7c32b30";
-
-        return UserDto.builder().tenantUrn(accountUrn).userUrn(userUrn)
-                .username(username).authorities(Arrays.asList("https://authorities.smartcosmos.net/things/read")).build();
-
     }
 }

--- a/src/main/java/net/smartcosmos/cluster/userdetails/domain/AuthenticateDetails.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/domain/AuthenticateDetails.java
@@ -1,0 +1,28 @@
+package net.smartcosmos.cluster.userdetails.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class AuthenticateDetails {
+
+    @JsonProperty("grant_type")
+    private String grantType;
+
+    @JsonProperty("password")
+    private String password;
+
+    @JsonProperty("scope")
+    private String scope;
+
+    @JsonProperty("username")
+    private String username;
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/domain/AuthenticateRequest.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/domain/AuthenticateRequest.java
@@ -1,0 +1,34 @@
+package net.smartcosmos.cluster.userdetails.domain;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+/**
+ * DTO representation of serialized {@link UsernamePasswordAuthenticationToken}.
+ */
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class AuthenticateRequest {
+
+    private AuthenticateDetails details;
+
+    private List<String> authorities;
+
+    private Boolean authenticated;
+
+    private String principal;
+
+    private String credentials;
+
+    private String name;
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/domain/UserDto.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/domain/UserDto.java
@@ -19,7 +19,7 @@ import lombok.*;
 public class UserDto {
 
     @NonNull
-    private final String accountUrn;
+    private final String tenantUrn;
 
     @NonNull
     private final String userUrn;
@@ -30,5 +30,5 @@ public class UserDto {
     private String passwordHash;
 
     @NonNull
-    private List<String> roles;
+    private List<String> authorities;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change introduces a common interface for getting authorities and aims for future support for multiple tenants containing the same usernames.

For that, username would be something like `myTenant:myUserName` or `myTenant/myUserName`. The string would be parsed in the user details service. Thus, the separator between user and tenant could be configurable, and each user service implementation would be able to decide to which extent it supports multi-tenancy.

Note that this wasn't possible if the endpoint continued to be `/{username}`, because that would end up being `/myTenant/myUserName` which results in a `404 Not Found` or similar response, i.e. the `/` is not URL-encoded.

**Changes in overview:**
- removes unused fallback endpoint `GET /{username}`
- changes `POST /{username}` to `POST /authenticate`
- adds in DTO models for Spring's `UsernamePasswordAuthenticationToken`
- updates README accordingly
### How is this patch documented?

Code, README.
### How was this patch tested?

Manually in Postman.
#### Depends On

Nothing, but impacts the JWT token generation in the Auth server, because the endpoint called from there won't be available anymore.
